### PR TITLE
Added `prune` subcommand

### DIFF
--- a/persist-core/src/protocol/request.rs
+++ b/persist-core/src/protocol/request.rs
@@ -68,6 +68,12 @@ pub struct LogsRequest {
     pub stream: bool,
     pub lines: usize,
 }
+/// A request to prune logs and pid files of unmanaged and/or stopped processes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PruneRequest {
+    /// Prune files from stopped, but still managed, processes.
+    pub stopped: bool,
+}
 
 /// A request (from a client to the daemon).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +88,7 @@ pub enum Request {
     Dump(DumpRequest),
     Restore(RestoreRequest),
     Logs(LogsRequest),
+    Prune(PruneRequest),
     Version,
     Kill,
 }

--- a/persist-core/src/protocol/response.rs
+++ b/persist-core/src/protocol/response.rs
@@ -87,6 +87,13 @@ pub enum LogsResponse {
     Unsubscribed,
 }
 
+/// A response to prune unused log files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PruneResponse {
+    /// List of the names of all the successfully pruned files.
+    pub pruned_files: Vec<String>,
+}
+
 /// A response (from the daemon to a client).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
@@ -101,5 +108,6 @@ pub enum Response {
     Restore(Vec<RestoreResponse>),
     Version(VersionResponse),
     Logs(LogsResponse),
+    Prune(PruneResponse),
     Error(String),
 }

--- a/persist-daemon/src/server/handle.rs
+++ b/persist-daemon/src/server/handle.rs
@@ -52,6 +52,10 @@ impl ProcessHandle {
         self.process.as_ref().map(|handle| handle.pid() as usize)
     }
 
+    pub fn pid_file(&self) -> &Path {
+        self.spec.pid_path.as_path()
+    }
+
     pub fn stdout_file(&self) -> &Path {
         self.spec.stdout_path.as_path()
     }

--- a/persist-daemon/src/server/mod.rs
+++ b/persist-daemon/src/server/mod.rs
@@ -42,6 +42,7 @@ pub async fn handle_conn(state: Arc<State>, conn: UnixStream) -> Result<(), Erro
             Request::Delete(request) => delete::handle(state.clone(), &mut framed, request).await,
             Request::Dump(request) => dump::handle(state.clone(), &mut framed, request).await,
             Request::Restore(request) => restore::handle(state.clone(), &mut framed, request).await,
+            Request::Prune(request) => prune::handle(state.clone(), &mut framed, request).await,
             Request::Version => daemon::version::handle(&mut framed).await,
             Request::Kill => std::process::exit(0),
         };

--- a/persist-daemon/src/server/request/mod.rs
+++ b/persist-daemon/src/server/request/mod.rs
@@ -4,6 +4,7 @@ pub mod dump;
 pub mod info;
 pub mod list;
 pub mod logs;
+pub mod prune;
 pub mod restart;
 pub mod restore;
 pub mod start;

--- a/persist-daemon/src/server/request/prune.rs
+++ b/persist-daemon/src/server/request/prune.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use futures::sink::SinkExt;
+use tokio::net::UnixStream;
+use tokio_util::codec::{Framed, LinesCodec};
+
+use persist_core::error::Error;
+use persist_core::protocol::{PruneRequest, PruneResponse, Response};
+
+use crate::server::State;
+
+pub async fn handle(
+    state: Arc<State>,
+    conn: &mut Framed<UnixStream, LinesCodec>,
+    req: PruneRequest,
+) -> Result<(), Error> {
+    let pruned_files = state.prune(req.stopped).await?;
+
+    let response = PruneResponse { pruned_files };
+    let response = Response::Prune(response);
+    let serialized = json::to_string(&response)?;
+    conn.send(serialized).await?;
+
+    Ok(())
+}

--- a/persist-daemon/src/server/request/restore.rs
+++ b/persist-daemon/src/server/request/restore.rs
@@ -5,6 +5,7 @@ use futures::sink::SinkExt;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Framed, LinesCodec};
 
+use persist_core::daemon::{self, LOGS_DIR, PIDS_DIR};
 use persist_core::error::Error;
 use persist_core::protocol::{Response, RestoreRequest, RestoreResponse};
 
@@ -17,12 +18,46 @@ pub async fn handle(
 ) -> Result<(), Error> {
     let futures = req.specs.into_iter().map(|spec| async {
         let name = spec.name.clone();
+
+        //? get dirs paths
+        let home_dir = daemon::home_dir()?;
+        let pids_dir = home_dir.join(PIDS_DIR);
+        let logs_dir = home_dir.join(LOGS_DIR);
+
+        //? ensure they exists
+        let future = future::join(
+            tokio::fs::create_dir(&pids_dir),
+            tokio::fs::create_dir(&logs_dir),
+        );
+        let _ = future.await;
+
+        //? get PID file path
+        let pid_path = format!("{}.pid", spec.name);
+        let pid_path = pids_dir.join(pid_path);
+
+        //? get stdout file path
+        let stdout_path = format!("{}-out.log", spec.name);
+        let stdout_path = logs_dir.join(stdout_path);
+
+        //? get stderr file path
+        let stderr_path = format!("{}-err.log", spec.name);
+        let stderr_path = logs_dir.join(stderr_path);
+
+        //? ensure they exists
+        let future = future::join3(
+            tokio::fs::File::create(pid_path.as_path()),
+            tokio::fs::File::create(stdout_path.as_path()),
+            tokio::fs::File::create(stderr_path.as_path()),
+        );
+        let _ = future.await;
+
         let res = state.clone().start(spec).await;
         let error = res.err().map(|err| err.to_string());
-        RestoreResponse { name, error }
+
+        Ok::<_, Error>(RestoreResponse { name, error })
     });
 
-    let responses = future::join_all(futures).await;
+    let responses = future::try_join_all(futures).await?;
     let response = Response::Restore(responses);
     let serialized = json::to_string(&response)?;
     conn.send(serialized).await?;

--- a/persist/src/commands/mod.rs
+++ b/persist/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod dump;
 pub mod info;
 pub mod list;
 pub mod logs;
+pub mod prune;
 pub mod restart;
 pub mod restore;
 pub mod start;

--- a/persist/src/commands/prune.rs
+++ b/persist/src/commands/prune.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+use persist_core::error::Error;
+use persist_core::protocol::PruneRequest;
+
+use crate::daemon;
+use crate::format;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, StructOpt)]
+pub struct Opts {
+    /// Also prune file of stopped, but still managed, processes.
+    #[structopt(long)]
+    pub stopped: bool,
+}
+
+pub async fn handle(opts: Opts) -> Result<(), Error> {
+    let request = PruneRequest {
+        stopped: opts.stopped,
+    };
+
+    let mut daemon = daemon::connect().await?;
+    let response = daemon.prune(request).await?;
+
+    if !response.pruned_files.is_empty() {
+        for pruned_file in response.pruned_files {
+            let msg = format!("'{}' successfully pruned", pruned_file);
+            format::success(msg);
+        }
+    } else {
+        format::success("nothing to prune");
+    }
+
+    Ok(())
+}

--- a/persist/src/daemon/client.rs
+++ b/persist/src/daemon/client.rs
@@ -290,4 +290,28 @@ impl DaemonClient {
 
         Ok(responses)
     }
+
+    pub async fn prune(&mut self, request: PruneRequest) -> Result<PruneResponse, Error> {
+        let request = Request::Prune(request);
+        let serialized = json::to_string(&request)?;
+
+        self.socket.send(serialized).await?;
+
+        let response = if let Some(response) = self.socket.next().await {
+            let response = response?;
+            json::from_str::<Response>(response.as_str())?
+        } else {
+            return Err(Error::from(String::from(
+                "daemon closed connection without responding",
+            )));
+        };
+
+        let response = match response {
+            Response::Prune(response) => response,
+            Response::Error(err) => return Err(Error::from(err)),
+            _ => return Err(Error::from(String::from("unexpected response from daemon"))),
+        };
+
+        Ok(response)
+    }
 }

--- a/persist/src/main.rs
+++ b/persist/src/main.rs
@@ -36,6 +36,8 @@ pub enum Opts {
     Dump(commands::dump::Opts),
     /// Restore previously dumped processes
     Restore(commands::restore::Opts),
+    /// Prune outdated process logs and pid files
+    Prune(commands::prune::Opts),
 }
 
 #[tokio::main]
@@ -53,6 +55,7 @@ async fn main() -> Result<(), Error> {
         Opts::Logs(opts) => commands::logs::handle(opts).await,
         Opts::Dump(opts) => commands::dump::handle(opts).await,
         Opts::Restore(opts) => commands::restore::handle(opts).await,
+        Opts::Prune(opts) => commands::prune::handle(opts).await,
     };
 
     if let Err(err) = outcome {


### PR DESCRIPTION
This PR adds support for the `persist prune` subcommand.  

This command allows to prune non-needed logs and PID files within the `.persist` directory from no longer managed processes, with options to:
- also prune files from stopped, but still managed, processes

Here is the output of `persist prune --help`, for details:
```plain
persist-prune 0.1.0
Prune outdated process logs and pid files

USAGE:
    persist prune [FLAGS]

FLAGS:
    -h, --help       Prints help information
        --stopped    Also prune file of stopped, but still managed, processes
    -V, --version    Prints version information
```

**Depends on #6.**