### PR TITLE
Treat CR (`\r`) as a line-terminating character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
 name = "persist-daemon"
 version = "0.1.0"
 dependencies = [
+ "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heim 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,11 +76,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "loom 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cc"
@@ -214,6 +211,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,18 +336,6 @@ dependencies = [
  "proc-macro-hack 0.5.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-nested 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -603,16 +596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "generator 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "macaddr"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +757,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persist-core 0.1.0",
@@ -969,11 +953,6 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,7 +1123,7 @@ name = "tokio"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,7 +1156,7 @@ name = "tokio-util"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1290,7 +1269,7 @@ dependencies = [
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum bytes 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+"checksum bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 "checksum cc 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
@@ -1306,6 +1285,7 @@ dependencies = [
 "checksum darwin-libproc-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+"checksum dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
 "checksum dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
@@ -1320,7 +1300,6 @@ dependencies = [
 "checksum futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 "checksum futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 "checksum futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
-"checksum generator 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum heim 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28f11cfed41a4703f8f56ccbe411073c52bd3996d92e3ccac90d36bd0e86e0eb"
@@ -1344,7 +1323,6 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum loom 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
 "checksum macaddr 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bee538cb1031f87f970ba28f0e5ebfcdaf63ed1a000a4176b4117537c33d19fb"
 "checksum mach 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -1381,7 +1359,6 @@ dependencies = [
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-"checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"

--- a/persist-core/src/error.rs
+++ b/persist-core/src/error.rs
@@ -10,6 +10,8 @@ pub enum PersistError {
     ProcessNotFound,
     #[error("could not find home directory")]
     HomeDirNotFound,
+    #[error("could not find any running daemon")]
+    DaemonNotFound,
 }
 
 #[derive(Debug, Error)]

--- a/persist-core/src/protocol/mod.rs
+++ b/persist-core/src/protocol/mod.rs
@@ -60,6 +60,21 @@ pub struct ProcessInfo {
     pub created_at: chrono::NaiveDateTime,
 }
 
+impl From<ProcessInfo> for ProcessSpec {
+    fn from(info: ProcessInfo) -> ProcessSpec {
+        ProcessSpec {
+            name: info.name,
+            cmd: info.cmd,
+            cwd: info.cwd,
+            env: info.env,
+            pid_path: info.pid_path,
+            stdout_path: info.stdout_path,
+            stderr_path: info.stderr_path,
+            created_at: info.created_at,
+        }
+    }
+}
+
 /// The log stream source.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/persist-daemon/Cargo.toml
+++ b/persist-daemon/Cargo.toml
@@ -30,6 +30,7 @@ structopt = "0.3.7"
 # (de)serialization
 serde = { version = "1.0.104", features = ["derive"] }
 json = { package = "serde_json", version = "1.0.44" }
+bytes = "0.5.6"
 
 # misc
 chrono = { version = "0.4.10", features = ["serde"] }

--- a/persist-daemon/src/main.rs
+++ b/persist-daemon/src/main.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use nix::unistd::ForkResult;
 use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
@@ -36,10 +34,6 @@ fn main() -> Result<(), Error> {
             if let ForkResult::Parent { .. } = nix::unistd::fork()? {
                 std::process::exit(0);
             }
-
-            let home_dir = persist_core::daemon::home_dir()?;
-            let _ = std::fs::create_dir(&home_dir);
-            env::set_current_dir(home_dir)?;
 
             let mut runtime = Runtime::new()?;
             let outcome = runtime.block_on(server::start());

--- a/persist-daemon/src/server/codec.rs
+++ b/persist-daemon/src/server/codec.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+use bytes::BytesMut;
+use tokio_util::codec::Decoder;
+
+use persist_core::error::Error;
+
+#[derive(Debug, Clone, Default)]
+pub struct LogDecoder {
+    next_index: usize,
+}
+
+impl LogDecoder {
+    pub fn new() -> Self {
+        Self { next_index: 0 }
+    }
+}
+
+impl Decoder for LogDecoder {
+    type Item = String;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let mut iter = src[self.next_index..].iter().enumerate().peekable();
+
+        let position = loop {
+            let next = iter.next();
+            match next {
+                Some((index, b'\n')) => break Some(self.next_index + index),
+                // Special logic to not split twice when encountering a CRLF ("\r\n").
+                // We always wait for an additional character after a CR ('\r') and we make sure it isn't a LF ('\n').
+                Some((index, b'\r')) => match iter.peek() {
+                    Some((index, b'\n')) => break Some(self.next_index + index),
+                    None => break None,
+                    _ => break Some(self.next_index + index),
+                },
+                Some(_) => {}
+                None => {
+                    self.next_index = src.len();
+                    break None;
+                }
+            }
+        };
+
+        position
+            .map(|index| {
+                self.next_index = 0;
+                let line = src.split_to(index + 1);
+                let line = &line[..line.len() - 1];
+                let line = std::str::from_utf8(line).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Unable to decode input as UTF8")
+                })?;
+                Ok(line.to_string())
+            })
+            .transpose()
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.next_index = 0;
+
+        if src.is_empty() {
+            Ok(None)
+        } else {
+            let line = src.split();
+            let line = if matches!(line.last(), Some(b'\r')) {
+                &line[..line.len() - 1]
+            } else {
+                &line[..]
+            };
+            let line = std::str::from_utf8(line).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "Unable to decode input as UTF8")
+            })?;
+            Ok(Some(line.to_string()))
+        }
+    }
+}

--- a/persist-daemon/src/server/handle.rs
+++ b/persist-daemon/src/server/handle.rs
@@ -14,6 +14,8 @@ use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
 use persist_core::error::Error;
 use persist_core::protocol::{ProcessSpec, ProcessStatus};
 
+use crate::server::codec::LogDecoder;
+
 pub struct ProcessHandle {
     pub(crate) spec: ProcessSpec,
     pub(crate) process: Option<Process>,
@@ -122,8 +124,8 @@ impl ProcessHandle {
 
         let stdout = child.stdout.take().expect("failed to capture stdout");
         let stderr = child.stderr.take().expect("failed to capture stderr");
-        let mut stdout = FramedRead::new(stdout, LinesCodec::new());
-        let mut stderr = FramedRead::new(stderr, LinesCodec::new());
+        let mut stdout = FramedRead::new(stdout, LogDecoder::new());
+        let mut stderr = FramedRead::new(stderr, LogDecoder::new());
 
         let sender = self.stdout.clone();
         tokio::spawn(async move {

--- a/persist-daemon/src/server/mod.rs
+++ b/persist-daemon/src/server/mod.rs
@@ -8,6 +8,7 @@ use tokio_util::codec::{Framed, LinesCodec};
 pub mod handle;
 pub mod request;
 pub mod state;
+pub mod codec;
 
 use persist_core::daemon::{PID_FILE, SOCK_FILE};
 use persist_core::error::Error;

--- a/persist-daemon/src/server/mod.rs
+++ b/persist-daemon/src/server/mod.rs
@@ -5,10 +5,10 @@ use futures::stream::StreamExt;
 use tokio::net::{UnixListener, UnixStream};
 use tokio_util::codec::{Framed, LinesCodec};
 
+pub mod codec;
 pub mod handle;
 pub mod request;
 pub mod state;
-pub mod codec;
 
 use persist_core::daemon::{PID_FILE, SOCK_FILE};
 use persist_core::error::Error;

--- a/persist-daemon/src/server/request/delete.rs
+++ b/persist-daemon/src/server/request/delete.rs
@@ -18,8 +18,9 @@ pub async fn handle(
     let names = match req.filters {
         Some(filters) => filters,
         None => {
-            let future = state.with_handles(|handles| handles.keys().cloned().collect());
-            future.await
+            state
+                .with_handles(|handles| handles.keys().cloned().collect())
+                .await
         }
     };
 

--- a/persist-daemon/src/server/request/restart.rs
+++ b/persist-daemon/src/server/request/restart.rs
@@ -18,8 +18,9 @@ pub async fn handle(
     let names = match request.filters {
         Some(names) => names,
         None => {
-            let future = state.with_handles(|handles| handles.keys().cloned().collect());
-            future.await
+            state
+                .with_handles(|handles| handles.keys().cloned().collect())
+                .await
         }
     };
     let updated_env = request.env;

--- a/persist-daemon/src/server/request/restore.rs
+++ b/persist-daemon/src/server/request/restore.rs
@@ -5,7 +5,6 @@ use futures::sink::SinkExt;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Framed, LinesCodec};
 
-use persist_core::daemon::{self, LOGS_DIR, PIDS_DIR};
 use persist_core::error::Error;
 use persist_core::protocol::{Response, RestoreRequest, RestoreResponse};
 
@@ -18,38 +17,6 @@ pub async fn handle(
 ) -> Result<(), Error> {
     let futures = req.specs.into_iter().map(|spec| async {
         let name = spec.name.clone();
-
-        //? get dirs paths
-        let home_dir = daemon::home_dir()?;
-        let pids_dir = home_dir.join(PIDS_DIR);
-        let logs_dir = home_dir.join(LOGS_DIR);
-
-        //? ensure they exists
-        let future = future::join(
-            tokio::fs::create_dir(&pids_dir),
-            tokio::fs::create_dir(&logs_dir),
-        );
-        let _ = future.await;
-
-        //? get PID file path
-        let pid_path = format!("{}.pid", spec.name);
-        let pid_path = pids_dir.join(pid_path);
-
-        //? get stdout file path
-        let stdout_path = format!("{}-out.log", spec.name);
-        let stdout_path = logs_dir.join(stdout_path);
-
-        //? get stderr file path
-        let stderr_path = format!("{}-err.log", spec.name);
-        let stderr_path = logs_dir.join(stderr_path);
-
-        //? ensure they exists
-        let future = future::join3(
-            tokio::fs::File::create(pid_path.as_path()),
-            tokio::fs::File::create(stdout_path.as_path()),
-            tokio::fs::File::create(stderr_path.as_path()),
-        );
-        let _ = future.await;
 
         let res = state.clone().start(spec).await;
         let error = res.err().map(|err| err.to_string());

--- a/persist-daemon/src/server/request/start.rs
+++ b/persist-daemon/src/server/request/start.rs
@@ -1,11 +1,10 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use futures::future;
 use futures::sink::SinkExt;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Framed, LinesCodec};
 
-use persist_core::daemon::{self, LOGS_DIR, PIDS_DIR};
 use persist_core::error::Error;
 use persist_core::protocol::{ProcessSpec, Response, StartRequest, StartResponse};
 
@@ -16,55 +15,23 @@ pub async fn handle(
     conn: &mut Framed<UnixStream, LinesCodec>,
     spec: StartRequest,
 ) -> Result<(), Error> {
-    //? get dirs paths
-    let home_dir = daemon::home_dir()?;
-    let pids_dir = home_dir.join(PIDS_DIR);
-    let logs_dir = home_dir.join(LOGS_DIR);
-
-    //? ensure they exists
-    let future = future::join(
-        tokio::fs::create_dir(&pids_dir),
-        tokio::fs::create_dir(&logs_dir),
-    );
-    let _ = future.await;
-
-    //? get PID file path
-    let pid_path = format!("{}.pid", spec.name);
-    let pid_path = pids_dir.join(pid_path);
-
-    //? get stdout file path
-    let stdout_path = format!("{}-out.log", spec.name);
-    let stdout_path = logs_dir.join(stdout_path);
-
-    //? get stderr file path
-    let stderr_path = format!("{}-err.log", spec.name);
-    let stderr_path = logs_dir.join(stderr_path);
-
-    //? ensure they exists
-    let future = future::join3(
-        tokio::fs::File::create(pid_path.as_path()),
-        tokio::fs::File::create(stdout_path.as_path()),
-        tokio::fs::File::create(stderr_path.as_path()),
-    );
-    let _ = future.await;
-
-    //? construct process spec
     let now = chrono::Local::now().naive_local();
+
     let spec = ProcessSpec {
         name: spec.name,
         cmd: spec.cmd,
         env: spec.env,
         cwd: spec.cwd,
         created_at: now,
-        pid_path: pid_path.canonicalize()?,
-        stdout_path: stdout_path.canonicalize()?,
-        stderr_path: stderr_path.canonicalize()?,
+        pid_path: PathBuf::new(),
+        stdout_path: PathBuf::new(),
+        stderr_path: PathBuf::new(),
     };
 
     //? start the process according to that spec
-    state.start(spec.clone()).await?;
+    let info = state.start(spec).await?;
 
-    let response = Response::Start(StartResponse { spec });
+    let response = Response::Start(StartResponse { spec: info.into() });
     let serialized = json::to_string(&response)?;
     conn.send(serialized).await?;
 

--- a/persist-daemon/src/server/state.rs
+++ b/persist-daemon/src/server/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,7 +10,7 @@ use heim::units::information::byte;
 use heim::units::ratio;
 use tokio::sync::Mutex;
 
-use persist_core::daemon::{LOGS_DIR, PIDS_DIR};
+use persist_core::daemon::{self, LOGS_DIR, PIDS_DIR};
 use persist_core::error::{Error, PersistError};
 use persist_core::protocol::{
     ListResponse, LogEntry, LogStreamSource, ProcessInfo, ProcessSpec, ProcessStatus,
@@ -42,13 +43,13 @@ impl State {
     /// Executes a closure and provides it every process handles.
     ///
     /// This closure is executed while holding a lock, so avoid calling other methods on `State` inside that closure.
-    pub async fn with_handles<F, T>(&self, f: F) -> T
+    pub async fn with_handles<F, T>(&self, func: F) -> T
     where
         F: FnOnce(&HashMap<String, ProcessHandle>) -> T,
     {
         let processes = self.processes.lock().await;
 
-        f(&processes)
+        func(&processes)
     }
 
     /// Executes a closure and provides it the process handle of the specified process.
@@ -109,12 +110,51 @@ impl State {
         Ok(metrics)
     }
 
-    pub async fn start(self: Arc<Self>, spec: ProcessSpec) -> Result<ProcessInfo, Error> {
+    pub async fn start(self: Arc<Self>, mut spec: ProcessSpec) -> Result<ProcessInfo, Error> {
         let mut processes = self.processes.lock().await;
 
         if processes.contains_key(spec.name.as_str()) {
             return Err(Error::from(PersistError::ProcessAlreadyExists));
         }
+
+        //? get dirs paths
+        let home_dir = daemon::home_dir()?;
+        let pids_dir = home_dir.join(PIDS_DIR);
+        let logs_dir = home_dir.join(LOGS_DIR);
+
+        //? ensure they exists
+        let future = future::join(
+            tokio::fs::create_dir(&pids_dir),
+            tokio::fs::create_dir(&logs_dir),
+        );
+        let _ = future.await;
+
+        //? get PID file path
+        let pid_path = format!("{}.pid", spec.name);
+        let pid_path = pids_dir.join(pid_path);
+
+        //? get stdout file path
+        let stdout_path = format!("{}-out.log", spec.name);
+        let stdout_path = logs_dir.join(stdout_path);
+
+        //? get stderr file path
+        let stderr_path = format!("{}-err.log", spec.name);
+        let stderr_path = logs_dir.join(stderr_path);
+
+        //? ensure they exists
+        let future = future::join3(
+            tokio::fs::File::create(pid_path.as_path()),
+            tokio::fs::File::create(stdout_path.as_path()),
+            tokio::fs::File::create(stderr_path.as_path()),
+        );
+        let _ = future.await;
+
+        let now = chrono::Local::now().naive_local();
+
+        spec.created_at = now;
+        spec.pid_path = pid_path.canonicalize()?;
+        spec.stdout_path = stdout_path.canonicalize()?;
+        spec.stderr_path = stderr_path.canonicalize()?;
 
         processes.insert(spec.name.clone(), ProcessHandle::new(spec.clone()));
         let handle = processes.get_mut(&spec.name).unwrap();

--- a/persist-daemon/src/server/state.rs
+++ b/persist-daemon/src/server/state.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;

--- a/persist/Cargo.toml
+++ b/persist/Cargo.toml
@@ -33,3 +33,4 @@ json = { package = "serde_json", version = "1.0.44" }
 
 # miscellaneous
 chrono = { version = "0.4.10", features = ["serde"] }
+dirs = "3.0.1"

--- a/persist/src/commands/init.rs
+++ b/persist/src/commands/init.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+use persist_core::error::Error;
+
+use crate::daemon;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, StructOpt)]
+pub struct Opts {}
+
+pub async fn handle(_: Opts) -> Result<(), Error> {
+    daemon::init().await?;
+    Ok(())
+}

--- a/persist/src/commands/mod.rs
+++ b/persist/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod delete;
 pub mod dump;
 pub mod info;
+pub mod init;
 pub mod list;
 pub mod logs;
 pub mod prune;

--- a/persist/src/daemon/mod.rs
+++ b/persist/src/daemon/mod.rs
@@ -1,3 +1,5 @@
+use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use colored::Colorize;
@@ -56,7 +58,7 @@ pub async fn connect() -> Result<DaemonClient, Error> {
             let mut cur_exe = std::env::current_exe()?;
             cur_exe.set_file_name("persist-daemon");
 
-            let _ = tokio::fs::create_dir_all(&home_dir);
+            let _ = tokio::fs::create_dir_all(&home_dir).await;
 
             // Spawn the daemon.
             // (it is ok to await on it, because it should fork to daemonize early anyway).
@@ -76,4 +78,46 @@ pub async fn connect() -> Result<DaemonClient, Error> {
     };
 
     Ok(client)
+}
+
+pub async fn init() -> Result<(), Error> {
+    let dir = env::var("PERSIST_HOME")
+        .map(PathBuf::from)
+        .or_else(|_| env::current_dir().map(|path| path.join(".persist")))?;
+    let socket_path = dir.join(SOCK_FILE);
+
+    format::info(format!(
+        "considering installing daemon for: {}",
+        format::format_path(&dir).bold(),
+    ));
+
+    // if daemon doesn't exists, spawn it.
+    match DaemonClient::new(&socket_path).await {
+        Ok(_) => {
+            format::error("a live daemon is already controlling this location");
+        }
+        Err(_) => {
+            format::info("location is unoccupied, spawning daemon...");
+            let mut cur_exe = std::env::current_exe()?;
+            cur_exe.set_file_name("persist-daemon");
+
+            let _ = tokio::fs::create_dir_all(&dir).await;
+
+            // Spawn the daemon.
+            // (it is ok to await on it, because it should fork to daemonize early anyway).
+            let _ = Command::new(cur_exe)
+                .arg("start")
+                .current_dir(dir)
+                .spawn()?
+                .await?;
+
+            // Let some time to the daemon to fully initialize its environment.
+            tokio::time::delay_for(Duration::from_millis(250)).await;
+
+            DaemonClient::new(&socket_path).await?;
+            format::info("daemon spawned and ready for use.");
+        }
+    }
+
+    Ok(())
 }

--- a/persist/src/daemon/mod.rs
+++ b/persist/src/daemon/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 use tokio::process::Command;
@@ -41,6 +42,10 @@ pub async fn handle(opts: Opts) -> Result<(), Error> {
 
 pub async fn connect() -> Result<DaemonClient, Error> {
     let home_dir = persist_core::daemon::home_dir()?;
+    format::info(format!(
+        "using daemon from: {}",
+        format::format_path(&home_dir).bold(),
+    ));
     let socket_path = home_dir.join(SOCK_FILE);
 
     // if daemon doesn't exists, spawn it.
@@ -51,9 +56,15 @@ pub async fn connect() -> Result<DaemonClient, Error> {
             let mut cur_exe = std::env::current_exe()?;
             cur_exe.set_file_name("persist-daemon");
 
+            let _ = tokio::fs::create_dir_all(&home_dir);
+
             // Spawn the daemon.
             // (it is ok to await on it, because it should fork to daemonize early anyway).
-            let _ = Command::new(cur_exe).arg("start").spawn()?.await?;
+            let _ = Command::new(cur_exe)
+                .arg("start")
+                .current_dir(home_dir)
+                .spawn()?
+                .await?;
 
             // Let some time to the daemon to fully initialize its environment.
             tokio::time::delay_for(Duration::from_millis(250)).await;

--- a/persist/src/format.rs
+++ b/persist/src/format.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::path::Path;
 
 use colored::Colorize;
 
@@ -12,4 +13,28 @@ pub fn success(msg: impl Display) {
 
 pub fn info(msg: impl Display) {
     println!("{} {}", "info:".blue().bold(), msg);
+}
+
+pub fn format_path(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    if let Some(home_dir) = dirs::home_dir() {
+        let mut components = path.components();
+        let matches = home_dir
+            .components()
+            .zip(components.by_ref())
+            .all(|(a, b)| a == b);
+
+        if matches {
+            let path = components.as_path();
+            if path.file_name().is_none() {
+                "~".to_string()
+            } else {
+                format!("~/{}", path.display())
+            }
+        } else {
+            path.display().to_string()
+        }
+    } else {
+        path.display().to_string()
+    }
 }

--- a/persist/src/main.rs
+++ b/persist/src/main.rs
@@ -25,6 +25,8 @@ pub enum Opts {
     Restart(commands::restart::Opts),
     /// Get information about a process
     Info(commands::info::Opts),
+    /// Initialize a new `persist` workspace in the current directory
+    Init(commands::init::Opts),
     /// Delete an existing process
     Delete(commands::delete::Opts),
     /// List all managed processes
@@ -50,6 +52,7 @@ async fn main() -> Result<(), Error> {
         Opts::Stop(opts) => commands::stop::handle(opts).await,
         Opts::Restart(opts) => commands::restart::handle(opts).await,
         Opts::Info(opts) => commands::info::handle(opts).await,
+        Opts::Init(opts) => commands::init::handle(opts).await,
         Opts::Delete(opts) => commands::delete::handle(opts).await,
         Opts::List(opts) => commands::list::handle(opts).await,
         Opts::Logs(opts) => commands::logs::handle(opts).await,


### PR DESCRIPTION
Many command-line utilities produce fancy outputs for interactive terminals using carriage returns (`\r`) to rewrite lines in their output, but some of them forget to use `isatty(1)` to decide whether or not the usage of carriage returns is appropriate (like `curl` for its progress bars or `aws-cli` for its upload/download progress indicators).
Because of this, these tools would not emit any `\n` and thus `persist logs` couldn't present anything because of its buffering by line (using `\n`).  

This PR changes the handling of logs so that `\r` counts as a line terminator, at the same title as `\n`, so that these tools can now observed appropriately in logs.  
The implementation also makes sure that CRLFs (`\r\n`) do not count as two line terminators, so if a CR (`\r`) is immediately followed by an LF (`\n`), they count together as a single line terminator.  

**Depends on #8.**